### PR TITLE
ARD1939::CheckValidState

### DIFF
--- a/InverterApp/src/ARD1939/ARD1939.h
+++ b/InverterApp/src/ARD1939/ARD1939.h
@@ -114,6 +114,7 @@ class ARD1939
     uint8_t GetSourceAddress(void);
     void DeleteMessageFilter(long lPGN);
     void CANInterpret(long* CAN_PGN, uint8_t* CAN_Message, int* CAN_MessageLen, uint8_t* CAN_DestAddr, uint8_t* CAN_SrcAddr, uint8_t* CAN_Priority);
+    bool CheckValidState(void);
   private:
     uint8_t f01(uint8_t, uint8_t*);
     bool f02(void);

--- a/InverterApp/src/ARD1939/j1939.cpp
+++ b/InverterApp/src/ARD1939/j1939.cpp
@@ -2,6 +2,7 @@
 #include <inttypes.h>
 #include <SPI.h>
 
+#include "CAN_SPEC/MotorControlUnitState.h"
 #include "CAN_SPEC/PGN.h"
 #include "ARD1939.h"
 
@@ -1330,5 +1331,16 @@ void ARD1939::CANInterpret(long* CAN_PGN, uint8_t* CAN_Message, int* CAN_Message
       InverterState.Occurrence_Count = CAN_Message[5] % 2;
       break;
     }
+  }
+}
+
+bool ARD1939::CheckValidState(void){
+  switch(InverterState.MCU_State){
+    case MCU_STDBY: 
+    case MCU_IGNIT_READY: 
+    case MCU_PWR_READY: 
+    case MCU_DRIVE_READY:
+    case MCU_NORM_OPS: return true; break;
+    default: return false; break;
   }
 }


### PR DESCRIPTION
add `ARD1939::CheckValidState` from `StateTransitionCheck` PR#9
as the merge conflicts weren't worth it. Also validated the
function works when powering on the inverter.