### PR TITLE
Xmas Break re-work

### DIFF
--- a/InverterApp/InverterApp.ino
+++ b/InverterApp/InverterApp.ino
@@ -72,9 +72,9 @@ void setup()
     xTaskCreate(
         TaskUpdateLCDs,
         "UpdateLCDs",
-        128,
+        256,
         NULL,
-        10,
+        3,
         NULL
     );
 
@@ -132,10 +132,15 @@ void TaskUpdateSevenSegments(void * pvParameters)
 void TaskUpdateLCDs(void * pvParameters)
 {
     (void) pvParameters;
+    TickType_t xLastWakeTime;
+    const TickType_t xFrequency = pdMS_TO_TICKS(100); // 100ms update interval
+    
+    xLastWakeTime = xTaskGetTickCount();
+    
     for (;;)
     {
         gpioMan.UpdateLCDs();
-        vTaskDelay(70); // 15ms x 50 = 750ms
+        vTaskDelayUntil(&xLastWakeTime, xFrequency);  // Consistent timing
     }
 }
 

--- a/InverterApp/InverterApp.ino
+++ b/InverterApp/InverterApp.ino
@@ -18,8 +18,8 @@ void(* resetFunc) (void) = 0; //declare reset function @ address 0
 #define InverterSA 0xA2 // Shouldn't be hard coded
 uint8_t LastCommandedInverterState = MCU_STDBY;
 bool InitialState = true;
-bool InverterPowerOffState = false;
-bool InverterNormalOpState = false;
+bool InverterPowerOffState = false;  // Flag indicating inverter shutdown
+bool InverterNormalOpState = false;  // Flag indicating normal operation achieved
 
 // Common TaskScheduler/GPIOHandler pointer struct
 struct ManagerPointers
@@ -54,18 +54,18 @@ void setup()
     xTaskCreate(
         TaskClearFaults,
         "ClearFaults",
-        128,
+        192,
         NULL,
-        8,
+        4,
         NULL
     );
 
     xTaskCreate(
         TaskUpdateSevenSegments,
         "UpdateSevenSegments",
-        128,
+        192,
         NULL,
-        7,
+        2,
         NULL
     );
 
@@ -74,25 +74,25 @@ void setup()
         "UpdateLCDs",
         256,
         NULL,
-        3,
+        2,
         NULL
     );
 
     xTaskCreate(
         TaskCANLoop,
         "CANLoop",
-        256,
+        384,
         NULL,
-        7,
+        5,
         NULL
     );
 
     xTaskCreate(
         TaskInverterStateMachineControl,
         "InverterStateMachineControl",
-        128,
+        256,
         NULL,
-        8,
+        6,
         NULL
     );
 
@@ -108,6 +108,9 @@ void loop()
 void TaskClearFaults(void * pvParameters)
 {
     (void) pvParameters;
+    TickType_t xLastWakeTime = xTaskGetTickCount();
+    const TickType_t xFrequency = pdMS_TO_TICKS(10);
+    
     for (;;)
     {
         uint16_t ClearPinVal = gpioMan.GetClearPin(); 
@@ -115,17 +118,20 @@ void TaskClearFaults(void * pvParameters)
         {
             taskMan.ClearInverterFaults();
         }
-        vTaskDelay(1); // 15ms x 50 = 750ms
+        vTaskDelayUntil(&xLastWakeTime, xFrequency);
     }
 }
 
 void TaskUpdateSevenSegments(void * pvParameters)
 {
     (void) pvParameters;
+    TickType_t xLastWakeTime = xTaskGetTickCount();
+    const TickType_t xFrequency = pdMS_TO_TICKS(50);
+    
     for (;;)
     {
         gpioMan.UpdateSevenSegments();
-        vTaskDelay(3); // 15ms x 50 = 750ms
+        vTaskDelayUntil(&xLastWakeTime, xFrequency);
     }
 }
 
@@ -147,6 +153,9 @@ void TaskUpdateLCDs(void * pvParameters)
 void TaskCANLoop(void * pvParameters)
 {
     (void) pvParameters;
+    TickType_t xLastWakeTime = xTaskGetTickCount();
+    const TickType_t xFrequency = pdMS_TO_TICKS(5);
+    
     for (;;)
     {
         #ifndef USE_APPS
@@ -155,131 +164,161 @@ void TaskCANLoop(void * pvParameters)
         taskMan.UpdateSpeed(gpioMan.GetPedalTorque(), INVERTER_CMD_MESSAGE_INDEX);
         #endif
         taskMan.RunLoop();
-        vTaskDelay(1);
+        vTaskDelayUntil(&xLastWakeTime, xFrequency);
+    }
+}
+
+// State machine transition structure
+struct StateTransition {
+    uint8_t currentState;
+    uint8_t nextState;
+    uint8_t transitionCommand;
+    const char* stateMessage;
+};
+
+// Define state transitions table
+const StateTransition stateTransitions[] = {
+    {MCU_STDBY, MCU_FUNCTIONAL_DIAG, STDBY_TO_FUNCTIONAL_DIAG, "Transitioning to Functional Diagnostics"},
+    {MCU_FUNCTIONAL_DIAG, MCU_IGNIT_READY, STDBY_TO_IGNIT_READY, "Transitioning to Ignition Ready"},
+    {MCU_IGNIT_READY, MCU_PWR_READY, NO_CHANGE, "Waiting for Power Ready"}, // Auto transition
+    {MCU_PWR_READY, MCU_DRIVE_READY, PWR_READY_TO_DRIVE_READY, "Transitioning to Drive Ready"},
+    {MCU_DRIVE_READY, MCU_NORM_OPS, DRIVE_READY_TO_NORM_OPS, "Transitioning to Normal Operation"}
+};
+
+// Helper function to find and execute state transition
+void executeStateTransition(uint8_t currentState) {
+    static unsigned long lastStateChangeTime = 0;
+    const unsigned long STATE_CHANGE_DELAY = 500; // 500ms minimum between state changes
+    
+    // Don't process transitions too quickly
+    if (millis() - lastStateChangeTime < STATE_CHANGE_DELAY) {
+        return;
+    }
+    
+    // Find matching transition
+    for (const StateTransition& transition : stateTransitions) {
+        if (transition.currentState == currentState) {
+            // Log state change
+            Serial.print("Current State: 0x");
+            Serial.print(currentState, HEX);
+            Serial.print(" - ");
+            Serial.println(transition.stateMessage);
+            
+            // Execute transition if command exists
+            if (transition.transitionCommand != NO_CHANGE) {
+                taskMan.ChangeState(transition.transitionCommand, INVERTER_CMD_MESSAGE_INDEX);
+                LastCommandedInverterState = transition.nextState;
+            }
+            
+            lastStateChangeTime = millis();
+            break;
+        }
+    }
+}
+
+void handleFaultState(uint8_t faultState) {
+    if (LastCommandedInverterState != MCU_STDBY) {
+        Serial.print("Fault detected: 0x");
+        Serial.println(faultState, HEX);
+        Serial.println("Transitioning to Standby");
+        LastCommandedInverterState = MCU_STDBY;
     }
 }
 
 void TaskInverterStateMachineControl(void * pvParameters)
 {
     (void) pvParameters;
-
+    TickType_t xLastWakeTime = xTaskGetTickCount();
+    const TickType_t xFrequency = pdMS_TO_TICKS(20); // 20ms interval
+    static uint8_t initRetries = 0;
+    const uint8_t MAX_INIT_RETRIES = 3;
+    static unsigned long lastCANStatusTime = 0;
+    const unsigned long CAN_STATUS_INTERVAL = 5000; // Print CAN status every 5 seconds
+    
     for (;;)
     {
-        if (InverterState.CAN_Bus_Status == ADDRESSCLAIM_FINISHED)
+        if (InitialState)
         {
-            if (InverterState.MCU_State != MCU_FAIL_SAFE || InverterState.MCU_State != MCU_CNTRL_PWR_DOWN)
+            if (InverterState.CAN_Bus_Status != ADDRESSCLAIM_FINISHED)
             {
-                InverterPowerOffState = false;
+                Serial.println("Waiting for CAN bus initialization...");
+                vTaskDelayUntil(&xLastWakeTime, xFrequency);
+                continue;
             }
-            if(InverterState.MCU_State != MCU_NORM_OPS)
+
+            uint8_t currentState = InverterState.MCU_State;
+            
+            // If not in standby, try to get there
+            if (currentState != MCU_STDBY && currentState != MCU_PWR_UP)
             {
-                InverterNormalOpState = false;
-            }
-            switch(InverterState.MCU_State)
-            {
-                case MCU_STDBY:
-                    if(InitialState || LastCommandedInverterState == InverterState.MCU_State)
-                    {
-                        Serial.println("Inverter in Standby State");
-                    }
-                    
-                    taskMan.ChangeState(STDBY_TO_FUNCTIONAL_DIAG, INVERTER_CMD_MESSAGE_INDEX);
-                    LastCommandedInverterState = MCU_FUNCTIONAL_DIAG;      
-                    break;
-                case MCU_FUNCTIONAL_DIAG:
-                    if(InitialState || LastCommandedInverterState == InverterState.MCU_State)
-                    {
-                        Serial.println("Inverter in Functional Diagnostics State");
-                        Serial.println("Inverter will automatically transition to Ignition Ready");
-                    }
-                    taskMan.ChangeState(STDBY_TO_IGNIT_READY, INVERTER_CMD_MESSAGE_INDEX);
-                    LastCommandedInverterState = MCU_IGNIT_READY;      
-                    break;
-                case MCU_IGNIT_READY:
-                    if(InitialState || LastCommandedInverterState == InverterState.MCU_State)
-                    {
-                        Serial.println("Inverter in Ignition Ready State");
-                        Serial.println("Inverter will automatically transition to Power Ready");
-                        Serial.println("Connect HVDC Bus");
-                    }
-                    LastCommandedInverterState = MCU_PWR_READY;  
-                    break;
-                case MCU_PWR_READY:
-                    if(InitialState || LastCommandedInverterState == InverterState.MCU_State)
-                    {
-                        Serial.println("Inverter in Power Ready State");
-                        Serial.println("Commanding Inverter to Drive Ready");
-                    }
-                    taskMan.ChangeState(PWR_READY_TO_DRIVE_READY, INVERTER_CMD_MESSAGE_INDEX);
-                    LastCommandedInverterState = MCU_DRIVE_READY;  
-                    break;
-                case MCU_PWR_DIAG:
-
-                    break;
-                case MCU_DRIVE_READY:
-                    if(InitialState || LastCommandedInverterState == InverterState.MCU_State)
-                    {
-                        Serial.println("Inverter in Drive Ready State");
-                        Serial.println("Commanding Inverter to Normal Operation");
-                    }
-                    taskMan.ChangeState(DRIVE_READY_TO_NORM_OPS, INVERTER_CMD_MESSAGE_INDEX);
-                    LastCommandedInverterState = MCU_NORM_OPS; 
-                    break;
-                case MCU_NORM_OPS:
-                    if(InitialState || (LastCommandedInverterState == InverterState.MCU_State && !InverterNormalOpState))
-                    {
-                        Serial.println("Inverter in Normal Operation State");
-                    }
-                    InverterNormalOpState = true;
-                    break;
-
-                case MCU_CNTRL_PWR_DOWN:
-                    InverterPowerOffState = true;
-                    Serial.println("Inverter in Controlled Power Down State");
-                    Serial.println("Inverter Powering Down");
-                    LastCommandedInverterState = MCU_STDBY;
-                    break;
-                case MCU_FAIL_SAFE:
-                    InverterPowerOffState = true;
-                    Serial.println("Inverter in Fail Safe State");
-                    Serial.println("Inverter Powering Down");
-                    LastCommandedInverterState = MCU_STDBY;
-                    break;
-                case MCU_FAULT_CLASSA:
-                    if(InitialState || LastCommandedInverterState == InverterState.MCU_State)
-                    {
-                        Serial.println("Inverter in Class A Fault State");
-                        Serial.println("Commanding Inverter to Standby");
-                    }
-                    //taskMan.ClearInverterFaults();
-                    LastCommandedInverterState = MCU_STDBY;
-                    break;
-                case MCU_FAULT_CLASSB:
-                    if(InitialState || LastCommandedInverterState == InverterState.MCU_State)
-                    {
-                        Serial.println("Inverter in Class B Fault State");
-                        Serial.println("Commanding Inverter to Standby");
-                    }
-                    //taskMan.ClearInverterFaults();
-                    LastCommandedInverterState = MCU_STDBY;
-                    break;
-                case MCU_ADV_DIAG_CLASSA:
-
-                    break;
-                case MCU_DISCHARGE_DIAG:
+                Serial.print("Error: Device not in standby state. Current state: 0x");
+                Serial.println(currentState, HEX);
                 
-                    break;
-                case MCU_ADV_DIAG_CLASSB:
-
-                    break;
-                default:
-                    break;
+                // If in a fault state, try to transition to standby
+                if (currentState == MCU_FAULT_CLASSA)
+                {
+                    Serial.println("Attempting to clear Class A fault and return to standby...");
+                    taskMan.ChangeState(FAULT_CLASSA_TO_STDBY, INVERTER_CMD_MESSAGE_INDEX);
+                }
+                else if (currentState == MCU_FAULT_CLASSB)
+                {
+                    Serial.println("Attempting to transition from Class B fault to Power Ready...");
+                    taskMan.ChangeState(FAULT_CLASSB_TO_PWR_READY, INVERTER_CMD_MESSAGE_INDEX);
+                }
+                else
+                {
+                    Serial.println("Unable to automatically transition to standby.");
+                }
+                
+                initRetries++;
+                if (initRetries >= MAX_INIT_RETRIES)
+                {
+                    Serial.println("ERROR: Maximum initialization retries reached. Manual intervention required.");
+                    while(1) { vTaskDelay(portMAX_DELAY); } // Stop trying to initialize
+                }
+                
+                vTaskDelayUntil(&xLastWakeTime, xFrequency);
+                continue;
             }
-            if(InitialState)
+            
+            // If we get here, we're in standby and can start normal initialization
+            Serial.println("Device in standby state, beginning initialization sequence...");
+            taskMan.ChangeState(STDBY_TO_FUNCTIONAL_DIAG, INVERTER_CMD_MESSAGE_INDEX);
+            InitialState = false;
+            LastCommandedInverterState = MCU_FUNCTIONAL_DIAG;
+            initRetries = 0;
+        }
+        else if (InverterState.CAN_Bus_Status == ADDRESSCLAIM_FINISHED)
+        {
+            uint8_t currentState = InverterState.MCU_State;
+            lastCANStatusTime = millis(); // Reset timer when CAN is working
+            
+            // Handle fault states
+            if (currentState == MCU_FAULT_CLASSA || currentState == MCU_FAULT_CLASSB || 
+                currentState == MCU_FAIL_SAFE)
             {
-                InitialState = false;
+                handleFaultState(currentState);
+            }
+            // Detect power down state
+            else if (currentState == MCU_CNTRL_PWR_DOWN && LastCommandedInverterState != MCU_STDBY)
+            {
+                Serial.println("Inverter powering down - ignition line low");
+                LastCommandedInverterState = MCU_STDBY;
+            }
+            // Handle normal state transitions
+            else if (!InverterPowerOffState)
+            {
+                executeStateTransition(currentState);
             }
         }
-        vTaskDelay(10); // 15ms * 10 = 150ms
+        else if (millis() - lastCANStatusTime >= CAN_STATUS_INTERVAL)
+        {
+            // Periodically report when CAN address claim isn't finished
+            Serial.print("Warning: CAN bus not ready. Status: 0x");
+            Serial.println(InverterState.CAN_Bus_Status, HEX);
+            lastCANStatusTime = millis();
+        }
+        
+        vTaskDelayUntil(&xLastWakeTime, xFrequency);
     }
 }

--- a/InverterApp/src/TaskScheduler/TaskScheduler.cpp
+++ b/InverterApp/src/TaskScheduler/TaskScheduler.cpp
@@ -475,12 +475,10 @@ void TaskScheduler::ClearInverterFaults(void)
     j1939.ClearFaults();
     if (InverterState.MCU_State == MCU_FAULT_CLASSA)
     {
-        Serial.println("State is MCU Class A");
         TaskScheduler::ChangeState(FAULT_CLASSA_TO_STDBY, INVERTER_CMD_MESSAGE_INDEX);
     }
     else if (InverterState.MCU_State == MCU_FAULT_CLASSB)
     {
-        Serial.println("State is MCU Class B");
         TaskScheduler::ChangeState(FAULT_CLASSB_TO_STDBY, INVERTER_CMD_MESSAGE_INDEX);
     }
 }

--- a/InverterApp/src/TaskScheduler/TaskScheduler.h
+++ b/InverterApp/src/TaskScheduler/TaskScheduler.h
@@ -8,14 +8,21 @@
 #include "../ARD1939/ARD1939.h"
 #include "../ARD1939/CAN_SPEC/PGN.h"
 
-enum {MAX_TASKS = 15};
+// We currntly support 3 tasks, and only use one. If needed we can add more.
+enum {MAX_TASKS = 3};
 #define INVERTER_CMD_MESSAGE_INDEX 0
+
+// Default CAN message configuration
+#define DEFAULT_INVERTER_CMD_PRIORITY 0x04
+#define DEFAULT_INVERTER_CMD_PGN COMMAND2_SPEED
+#define DEFAULT_INVERTER_CMD_DEST_ADDR 0xA2
+#define DEFAULT_INVERTER_CMD_MSG_LEN 8
+#define DEFAULT_INVERTER_CMD_INTERVAL 15
 
 struct CANTask
 {
     uint8_t priority;
     long PGN;
-    uint8_t srcAddr;
     uint8_t destAddr;
     int msgLen;
     unsigned long interval;
@@ -37,9 +44,20 @@ struct MsgReturn
 
 class TaskScheduler
 {
+    private:
+        void SendMessages();
+        void RecieveMessages();
+        int FirstFreeInCANTasks();
+        void SetupCANTask(uint8_t priority, long PGN, uint8_t destAddr, 
+                         int msgLen, unsigned long interval, uint8_t msg[J1939_MSGLEN], int index);
+        void SetupDefaultCANTasks();  // New private function to setup default CAN tasks
+        InitializedCANTask CANTasks[MAX_TASKS];
+        ARD1939 j1939;
+
     public:
         int Init();
-        int AddCANTask(uint8_t priority, long PGN, uint8_t srcAddr, uint8_t destAddr, int msgLen, unsigned long interval, uint8_t msg[J1939_MSGLEN]);
+        int AddCANTask(uint8_t priority, long PGN, uint8_t destAddr, 
+                      int msgLen, unsigned long interval, uint8_t msg[J1939_MSGLEN]);
         void RemoveCANTask(int taskIndex);
         MsgReturn GetMsg(int taskIndex);
         void UpdateMsg(int taskIndex, int msg[], int msgLen);
@@ -51,13 +69,6 @@ class TaskScheduler
         void EnableDriveMessage(void);
         void DisableDriveMessage(void);
         void ClearInverterFaults(void);
-    private:
-        void SendMessages();
-        void RecieveMessages();
-        int FirstFreeInCANTasks();
-        void SetupCANTask(uint8_t priority, long PGN, uint8_t srcAddr, uint8_t destAddr, int msgLen, unsigned long interval, uint8_t msg[J1939_MSGLEN], int index);
-        InitializedCANTask CANTasks[MAX_TASKS];
-        ARD1939 j1939;
 };
 
 #endif /* TASK_SCHEDULER_H */

--- a/InverterApp/src/gpioHandler/gpioHandler.h
+++ b/InverterApp/src/gpioHandler/gpioHandler.h
@@ -77,7 +77,6 @@ class GPIOHandler
         
         bool LcdInit();
         void LCDDisplaySAE();
-        void LcdUpdate();
         const char* getStateName(uint8_t state); // Helper to convert state to string
         
     public:

--- a/InverterApp/src/gpioHandler/gpioHandler.h
+++ b/InverterApp/src/gpioHandler/gpioHandler.h
@@ -4,8 +4,10 @@
 #include <stdlib.h>
 #include "../Time/TimeLib.h"
 #include <Arduino.h>
-#include "../TaskScheduler/TaskScheduler.h"
+#include "../FreeRTOS/src/Arduino_FreeRTOS.h"
+#include "../FreeRTOS/src/semphr.h"  // Add this for SemaphoreHandle_t
 // USE_APPS defined in powerMode.h
+#include "../TaskScheduler/TaskScheduler.h"
 #include "powerMode.h"
 
 #define POT_GPIO           A1
@@ -62,6 +64,15 @@
 
 class GPIOHandler
 {
+    private:
+        uint16_t speed;
+        char displayBuffer[4][20];  // Current display content
+        char newBuffer[4][20];      // New content to be displayed
+        bool needsUpdate;           // Flag to track if update is needed
+        SemaphoreHandle_t lcdMutex; // Protect LCD access
+        bool LcdInit();
+        void LCDDisplaySAE();
+        void LcdUpdate();
     public:
         bool Init(void);
         uint16_t GetPedalSpeed();
@@ -69,11 +80,7 @@ class GPIOHandler
         uint16_t GetPedalTorque();
         void UpdateLCDs();
         void UpdateSevenSegments();
-    private:
-        uint16_t speed;
-        bool LcdInit();
-        void LCDDisplaySAE();
-        void LcdUpdate();
+        void UpdateDisplayText(const char* text, uint8_t row, uint8_t col);
 };
 
 #endif /* GPIO_HANDLER_H */

--- a/InverterApp/src/gpioHandler/gpioHandler.h
+++ b/InverterApp/src/gpioHandler/gpioHandler.h
@@ -2,10 +2,13 @@
 #define GPIO_HANDLER_H
 
 #include <stdlib.h>
-#include "../Time/TimeLib.h"
 #include <Arduino.h>
+#include <LiquidCrystal.h>
+#include "../Time/TimeLib.h"
 #include "../FreeRTOS/src/Arduino_FreeRTOS.h"
 #include "../FreeRTOS/src/semphr.h"  // Add this for SemaphoreHandle_t
+#include "../ARD1939/CAN_SPEC/MotorControlUnitState.h" // For MCU states
+#include "../ARD1939/ARD1939.h"    // For CAN status codes
 // USE_APPS defined in powerMode.h
 #include "../TaskScheduler/TaskScheduler.h"
 #include "powerMode.h"
@@ -69,10 +72,14 @@ class GPIOHandler
         char displayBuffer[4][20];  // Current display content
         char newBuffer[4][20];      // New content to be displayed
         bool needsUpdate;           // Flag to track if update is needed
+        bool persistInfoLines;      // Flag to control info line persistence
         SemaphoreHandle_t lcdMutex; // Protect LCD access
+        
         bool LcdInit();
         void LCDDisplaySAE();
         void LcdUpdate();
+        const char* getStateName(uint8_t state); // Helper to convert state to string
+        
     public:
         bool Init(void);
         uint16_t GetPedalSpeed();
@@ -81,6 +88,17 @@ class GPIOHandler
         void UpdateLCDs();
         void UpdateSevenSegments();
         void UpdateDisplayText(const char* text, uint8_t row, uint8_t col);
+        
+        // Base LCD update functions
+        void UpdateLCD(const char* state, const char* fault, const char* info1, const char* info2);
+        void UpdateState(const char* state);
+        void UpdateFault(const char* fault);
+        void UpdateInfo(const char* info1, const char* info2, bool persist = false);
+        
+        // Specific display functions
+        void DisplayStateTransition(uint8_t state, const char* transitionMsg, bool persistInfo = false);
+        void DisplayFaultState(uint8_t state, const char* faultType, const char* action, bool persistInfo = true);
+        const char* getCANStatusName(uint8_t status); // Helper to convert CAN status to string
 };
 
 #endif /* GPIO_HANDLER_H */


### PR DESCRIPTION
Lots of updates:

- Add interface for easily displaying things to the LCD
  - Changes logic for updating the display with only changing the lines that are actually being updated
  - Replace all of our `Serial.print` calls to print things to the LCD instead
  - Initialize the I2C bus at 400khz instead of 100khz to allow display to update more quickly
- Rework the MachineControl state machine to be much easier to read
  - Handle faults slightly better
- Improve FreeRTOS configuration
  -  Rework task scheduling to be more consistent
  - Allocate more RAM to tasks that need it
  - More clearly wait for the CAN bus to actually be initialized and display it on the LCD
- J1939 Updates
  - Remove hardcoded source addresses in periodic CAN tasks
  - Split out SetupCANTasks into its own function
  - Print faults to the LCD directly instead of throwing them out over Serial 